### PR TITLE
Produce 32bit Linux executable on 64bit machines

### DIFF
--- a/ArduinoFloppyReader/ArduinoFloppyReader/makefile
+++ b/ArduinoFloppyReader/ArduinoFloppyReader/makefile
@@ -9,7 +9,7 @@
 CC = g++
 
 # define any compile-time flags
-CFLAGS = -Wall -std=c++14 -Wno-psabi -O3
+CFLAGS = -Wall -std=c++14 -Wno-psabi -O3 -m32
 
 # define any directories containing header files other than /usr/include
 #

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,23 @@ formatted DD floppy disks.
 Using the supplied makefile you should be able to **compile this on Linux**.  It has
 been tested with Raspberry Pi OS (Raspbian - Debian-based)
 
+# Compiling on Linux x64
+
+Makefile contains directives to produce 32bit executable. To make it usable, install these
+two libraries (in the example, using **apt** for Debian-based distros):
+
+* **sudo apt install gcc-multilib**
+* **sudo apt install g++-multilib**
+
+Then execute build command:
+
+* **cd ArduinoFloppyReader**
+* **cd ArduinoFloppyReader**
+* **make clean**
+* **make**
+
+It will produce **ArduinoReaderWriter** executable file.
+
 # Scripts for linux
 The above application apparently works under WINE, however,
 Github user "kollokollo" made some scripts for reading other formats on Linux 


### PR DESCRIPTION
This seems to fix issue #19: it produces a 32bit executable, suggested by @gianlucarenzi. Still don't know why it works this way (32bit executable), but not having a 64bit executable.

![image](https://user-images.githubusercontent.com/2118813/129555078-892365fe-accc-4283-9568-df5d46371a0d.png)
