### PR TITLE
fixed: make ArduinoFloppyReader compile under linux

### DIFF
--- a/ArduinoFloppyReader/lib/ADFWriter.cpp
+++ b/ArduinoFloppyReader/lib/ADFWriter.cpp
@@ -55,6 +55,9 @@ const long long StreamMax = std::numeric_limits<std::streamsize>::max();
 #else
 #include <algorithm>
 #include <netdb.h>
+#include <unistd.h>
+#define Sleep sleep
+#define memcpy_s(a,b,c,d) memcpy(a,c,d)
 #endif 
 
 #include "pll.h"
@@ -1407,7 +1410,7 @@ ADFResult ADFWriter::sectorFileToDisk(const std::wstring& inputFile, const bool 
 #else
 	std::string inputFileA;
 	quickw2a(inputFile, inputFileA);
-	std::ifstream hADFFile(inputFileA, std::ifstream::in | std::ifstream::binary);
+	std::ifstream hFile(inputFileA, std::ifstream::in | std::ifstream::binary);
 #endif
 	if (!hFile.is_open()) return ADFResult::adfrFileError;
 

--- a/ArduinoFloppyReader/lib/ibm_sectors.cpp
+++ b/ArduinoFloppyReader/lib/ibm_sectors.cpp
@@ -18,6 +18,10 @@
 #include <iomanip>
 #include <vector>
 #include <unordered_map>
+#ifndef _WIN32
+#include <cstring>
+#include <cmath>
+#endif
 #include "ibm_sectors.h"
 
 namespace IBM {


### PR DESCRIPTION
memcpy_s should work under linux but regardless where I've placed the needed defines the definition wasn't found. 